### PR TITLE
Use a specific osx_image for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ dist: trusty
 sudo: false
 
 # OS X only supports one image. Us the latest.
-osx_image:
-  - xcode8.2
-#  - xcode7.3
-#  - xcode6.4
+osx_image: xcode8.2
 
 git:
   depth: 3


### PR DESCRIPTION
Hello! 👋 

This change sets a specific value for the `osx_image` key in the .travis.yml file, instead of using a list syntax.

Hope this helps!